### PR TITLE
fix(crs): handle NA EPSG code in crs.Albers/crs.Lambert

### DIFF
--- a/R/GIS_Projection.R
+++ b/R/GIS_Projection.R
@@ -75,7 +75,7 @@ crs.Albers <- function(spx = NULL, ext = NULL) {
         stop("Spatial object must have a defined CRS", call. = FALSE)
       }
       # Transform to EPSG:4326 if not already
-      if (sf::st_crs(spx)$epsg != 4326) {
+      if (!isTRUE(sf::st_crs(spx)$epsg == 4326)) {
         spx <- sf::st_transform(spx, 4326)
       }
       bb <- sf::st_bbox(spx)
@@ -192,7 +192,7 @@ crs.Lambert <- function(spx = NULL, ext = NULL) {
         stop("Spatial object must have a defined CRS", call. = FALSE)
       }
       # Transform to EPSG:4326 if not already
-      if (sf::st_crs(spx)$epsg != 4326) {
+      if (!isTRUE(sf::st_crs(spx)$epsg == 4326)) {
         spx <- sf::st_transform(spx, 4326)
       }
       bb <- sf::st_bbox(spx)


### PR DESCRIPTION
## Summary
- Fix crash when `sf::st_crs(spx)$epsg` returns `NA` for CRS without registered EPSG code
- Affects both `crs.Albers()` and `crs.Lambert()` in `R/GIS_Projection.R`
- Uses `!isTRUE(... == 4326)` for NA-safe comparison

## Context
Found during Phase 3 integration testing (AutoSHUD #3). When AutoSHUD reads a watershed boundary without an explicit CRS file, rSHUD generates an Albers projection whose EPSG is NA, causing `crs.Albers()` to crash.

## Test plan
- [x] Config loads successfully with NA-EPSG CRS
- [x] AutoSHUD Step1/Step2/Step3 complete with v3 rSHUD
- [x] SHUD C++ solver runs 1825-day simulation to completion
- [x] Local NA-EPSG sf smoke test for `crs.Albers()` and `crs.Lambert()`
- [x] `Rscript -e 'library(testthat); source("R/GIS_Projection.R"); test_file("tests/testthat/test-projection.R")'` passed, 78 assertions
- [x] `R CMD build` passed and produced `rSHUD_2.2.0.tar.gz`
- [x] Tarball-level `R CMD check --no-manual` confirms package install/load, compiled code, tests, and installed docs pass
- [ ] Full tarball-level `R CMD check --no-manual` is still blocked by pre-existing v3 migration/documentation issues unrelated to this two-line CRS hotfix: `fishnet` legacy `sp` plotting example, vignette code that installs packages or references missing files/API drift, Rd usage warnings, and namespace NOTE. Tracked separately in https://github.com/SHUD-System/rSHUD/issues/5

## Agent Review
- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security and Performance Reviewer
- Reviewed head SHA: `534b345cde3a84613c9f2c5bca054cc2180bd1af`
- Review evidence: [Review 1](https://github.com/SHUD-System/rSHUD/pull/4#issuecomment-4358044779) | [Review 2](https://github.com/SHUD-System/rSHUD/pull/4#issuecomment-4358045222) | [Review 3](https://github.com/SHUD-System/rSHUD/pull/4#issuecomment-4358045552) | [Review 4](https://github.com/SHUD-System/rSHUD/pull/4#issuecomment-4358045966)
- Key findings addressed: No critical, major, or minor findings. Independent final review also found no must-fix items; remaining nice-to-have is adding a permanent NA-EPSG regression test later.
