### PR TITLE
fix(api): guard model builder CRS units

### DIFF
--- a/R/interface_main.R
+++ b/R/interface_main.R
@@ -48,7 +48,8 @@ NULL
 #' generation must have a defined projected CRS in metres/meters. Longitude/
 #' latitude CRS inputs and projected CRSs in non-metre units are rejected;
 #' transform inputs to an appropriate metre-based projected CRS before calling
-#' this workflow.
+#' this workflow. All supplied spatial inputs must use the same CRS as
+#' \code{domain}; this workflow does not auto-reproject.
 #'
 #' @return List with components:
 #'   \item{mesh}{SHUD.MESH object}
@@ -245,6 +246,24 @@ auto_build_model <- function(
   }
   if (!is.null(landcover)) {
     check_raster_projected_crs(landcover, "landcover")
+  }
+
+  check_model_builder_crs_match(dem, domain, "dem", "domain")
+  if (!is.null(rivers)) {
+    check_model_builder_crs_match(rivers, domain, "rivers", "domain")
+  }
+  if (!is.null(forcing_sites)) {
+    check_model_builder_crs_match(forcing_sites, domain,
+                                  "forcing_sites", "domain")
+  }
+  if (!is.null(soil)) {
+    check_model_builder_crs_match(soil, domain, "soil", "domain")
+  }
+  if (!is.null(geology)) {
+    check_model_builder_crs_match(geology, domain, "geology", "domain")
+  }
+  if (!is.null(landcover)) {
+    check_model_builder_crs_match(landcover, domain, "landcover", "domain")
   }
 
   # Validate numeric parameters

--- a/R/interface_main.R
+++ b/R/interface_main.R
@@ -43,6 +43,13 @@ NULL
 #' @param remove_outliers Logical, remove outliers in soil/geology data
 #' @param verbose Logical, display progress messages (default: TRUE)
 #'
+#' @details
+#' Inputs used for meter-based buffering, simplification, cropping, and mesh
+#' generation must have a defined projected CRS in metres/meters. Longitude/
+#' latitude CRS inputs and projected CRSs in non-metre units are rejected;
+#' transform inputs to an appropriate metre-based projected CRS before calling
+#' this workflow.
+#'
 #' @return List with components:
 #'   \item{mesh}{SHUD.MESH object}
 #'   \item{river}{SHUD.RIVER object}
@@ -219,6 +226,25 @@ auto_build_model <- function(
   }
   if (!is.null(forcing_sites) && !inherits(forcing_sites, "sf")) {
     stop("Parameter 'forcing_sites' must be an sf object", call. = FALSE)
+  }
+
+  # Meter-based distances in this workflow are unsafe in missing or geographic CRS.
+  check_sf_projected_crs(domain, "domain")
+  check_raster_projected_crs(dem, "dem")
+  if (!is.null(rivers)) {
+    check_sf_projected_crs(rivers, "rivers")
+  }
+  if (!is.null(forcing_sites)) {
+    check_sf_projected_crs(forcing_sites, "forcing_sites")
+  }
+  if (!is.null(soil)) {
+    check_raster_projected_crs(soil, "soil")
+  }
+  if (!is.null(geology)) {
+    check_raster_projected_crs(geology, "geology")
+  }
+  if (!is.null(landcover)) {
+    check_raster_projected_crs(landcover, "landcover")
   }
 
   # Validate numeric parameters
@@ -632,6 +658,10 @@ autoBuildModel <- function(indata, forcfiles = NULL, prjname = NULL, ...) {
 #'   \item Boundary simplification: 200 m
 #'   \item Aquifer depth: 10 m
 #' }
+#'
+#' Input CRS requirements are inherited from \code{\link{auto_build_model}}:
+#' spatial inputs must have a defined projected CRS in metres/meters because
+#' the workflow uses meter-based distances.
 #'
 #' For more control over parameters, use \code{\link{auto_build_model}}.
 #'

--- a/R/validators.R
+++ b/R/validators.R
@@ -177,6 +177,152 @@ check_spatial_compatible <- function(x, y, check_crs = TRUE,
   invisible(TRUE)
 }
 
+#' Require projected CRS in metre units for model-building workflows
+#'
+#' @param x sf object to validate
+#' @param name Character string, parameter name for error messages
+#' @return Invisible TRUE if valid, otherwise stops with error
+#' @keywords internal
+#' @noRd
+check_sf_projected_crs <- function(x, name = "x") {
+  crs <- sf::st_crs(x)
+
+  if (is.na(crs)) {
+    stop(
+      "Parameter '", name, "' must have a defined projected CRS in metres/meters ",
+      "for meter-based buffer/simplify/mesh generation.",
+      call. = FALSE
+    )
+  }
+
+  if (isTRUE(sf::st_is_longlat(x))) {
+    stop(
+      "Parameter '", name, "' uses a longitude/latitude CRS, which is not ",
+      "supported for meter-based buffer/simplify/mesh generation. ",
+      "Transform '", name, "' to a projected CRS in metres/meters first.",
+      call. = FALSE
+    )
+  }
+
+  check_projected_crs_type(crs, name)
+  check_crs_units_metres(crs$units_gdal, name)
+
+  invisible(TRUE)
+}
+
+#' Require projected CRS in metre units for terra rasters
+#'
+#' @param x terra SpatRaster to validate
+#' @param name Character string, parameter name for error messages
+#' @return Invisible TRUE if valid, otherwise stops with error
+#' @keywords internal
+#' @noRd
+check_raster_projected_crs <- function(x, name = "x") {
+  crs <- terra::crs(x)
+
+  if (is.null(crs) || is.na(crs) || identical(trimws(crs), "")) {
+    stop(
+      "Parameter '", name, "' must have a defined projected CRS in metres/meters ",
+      "for meter-based buffer/simplify/mesh generation.",
+      call. = FALSE
+    )
+  }
+
+  if (isTRUE(suppressWarnings(terra::is.lonlat(x)))) {
+    stop(
+      "Parameter '", name, "' uses a longitude/latitude CRS, which is not ",
+      "supported for meter-based buffer/simplify/mesh generation. ",
+      "Transform '", name, "' to a projected CRS in metres/meters first.",
+      call. = FALSE
+    )
+  }
+
+  sf_crs <- tryCatch(
+    sf::st_crs(crs),
+    error = function(e) sf::NA_crs_
+  )
+  check_projected_crs_type(sf_crs, name)
+  check_crs_units_metres(sf_crs$units_gdal, name)
+
+  invisible(TRUE)
+}
+
+check_projected_crs_type <- function(crs, name) {
+  wkt <- tryCatch(
+    normalize_crs_wkt(crs$wkt),
+    error = function(e) NA_character_
+  )
+
+  if (is.na(wkt)) {
+    stop(
+      "Parameter '", name, "' has a CRS that could not be parsed. ",
+      "A projected CRS in metres/meters is required for meter-based ",
+      "buffer/simplify/mesh generation.",
+      call. = FALSE
+    )
+  }
+
+  if (!grepl("^[[:space:]]*(PROJCRS|PROJCS)[[:space:]]*\\[", wkt)) {
+    stop(
+      "Parameter '", name, "' must have a projected CRS in metres/meters ",
+      "for meter-based buffer/simplify/mesh generation.",
+      call. = FALSE
+    )
+  }
+
+  invisible(TRUE)
+}
+
+check_crs_units_metres <- function(units, name) {
+  units <- normalize_crs_units(units)
+
+  if (is.na(units)) {
+    stop(
+      "Parameter '", name, "' has CRS units that could not be determined. ",
+      "A projected CRS in metres/meters is required for meter-based ",
+      "buffer/simplify/mesh generation.",
+      call. = FALSE
+    )
+  }
+
+  if (!tolower(units) %in% c("metre", "meter")) {
+    stop(
+      "Parameter '", name, "' must use a projected CRS in metres/meters ",
+      "for meter-based buffer/simplify/mesh generation; found CRS units '",
+      units, "'.",
+      call. = FALSE
+    )
+  }
+
+  invisible(TRUE)
+}
+
+normalize_crs_wkt <- function(wkt) {
+  if (is.null(wkt) || length(wkt) == 0 || all(is.na(wkt))) {
+    return(NA_character_)
+  }
+
+  wkt <- trimws(as.character(wkt[which(!is.na(wkt))[1]]))
+  if (!nzchar(wkt)) {
+    return(NA_character_)
+  }
+
+  wkt
+}
+
+normalize_crs_units <- function(units) {
+  if (is.null(units) || length(units) == 0 || all(is.na(units))) {
+    return(NA_character_)
+  }
+
+  units <- trimws(as.character(units[which(!is.na(units))[1]]))
+  if (!nzchar(units)) {
+    return(NA_character_)
+  }
+
+  units
+}
+
 #' Check if two CRS are compatible
 #'
 #' Determines if two coordinate reference systems are compatible.

--- a/R/validators.R
+++ b/R/validators.R
@@ -247,6 +247,47 @@ check_raster_projected_crs <- function(x, name = "x") {
   invisible(TRUE)
 }
 
+model_builder_crs_compatible <- function(x, y) {
+  crs_x <- model_builder_st_crs(x)
+  crs_y <- model_builder_st_crs(y)
+
+  if (is.na(crs_x) || is.na(crs_y)) {
+    return(FALSE)
+  }
+
+  isTRUE(tryCatch(crs_x == crs_y, error = function(e) FALSE))
+}
+
+check_model_builder_crs_match <- function(x, y, name_x = "x", name_y = "y") {
+  if (!model_builder_crs_compatible(x, y)) {
+    stop(
+      "Parameter '", name_x, "' CRS must match '", name_y, "' CRS",
+      call. = FALSE
+    )
+  }
+
+  invisible(TRUE)
+}
+
+model_builder_st_crs <- function(x) {
+  crs <- tryCatch(
+    {
+      if (inherits(x, c("SpatRaster", "SpatVector"))) {
+        sf::st_crs(terra::crs(x))
+      } else {
+        sf::st_crs(x)
+      }
+    },
+    error = function(e) sf::NA_crs_
+  )
+
+  if (is.na(crs)) {
+    return(sf::NA_crs_)
+  }
+
+  crs
+}
+
 check_projected_crs_type <- function(crs, name) {
   wkt <- tryCatch(
     normalize_crs_wkt(crs$wkt),

--- a/man/auto_build_model.Rd
+++ b/man/auto_build_model.Rd
@@ -94,7 +94,8 @@ Inputs used for meter-based buffering, simplification, cropping, and mesh
 generation must have a defined projected CRS in metres/meters. Longitude/
 latitude CRS inputs and projected CRSs in non-metre units are rejected;
 transform inputs to an appropriate metre-based projected CRS before calling
-this workflow.
+this workflow. All supplied spatial inputs must use the same CRS as
+\code{domain}; this workflow does not auto-reproject.
 }
 \section{Migration Note}{
 

--- a/man/auto_build_model.Rd
+++ b/man/auto_build_model.Rd
@@ -89,6 +89,13 @@ Automated workflow to build a complete SHUD hydrological model from
 geospatial data. This modernized function uses terra and sf exclusively
 for all spatial operations.
 }
+\details{
+Inputs used for meter-based buffering, simplification, cropping, and mesh
+generation must have a defined projected CRS in metres/meters. Longitude/
+latitude CRS inputs and projected CRSs in non-metre units are rejected;
+transform inputs to an appropriate metre-based projected CRS before calling
+this workflow.
+}
 \section{Migration Note}{
 
 This function replaces \code{autoBuildModel()} with modern spatial libraries.

--- a/man/quick_model.Rd
+++ b/man/quick_model.Rd
@@ -51,6 +51,10 @@ This function uses default parameters optimized for typical watersheds:
 \item Aquifer depth: 10 m
 }
 
+Input CRS requirements are inherited from \code{\link{auto_build_model}}:
+spatial inputs must have a defined projected CRS in metres/meters because
+the workflow uses meter-based distances.
+
 For more control over parameters, use \code{\link{auto_build_model}}.
 }
 \section{Migration Note}{

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -1,6 +1,58 @@
 # Integration Tests for Main Interface Functions
 # Tests for auto_build_model() and quick_model()
 
+test_projected_crs <- 3857
+
+create_integration_domain <- function(crs = test_projected_crs) {
+  coords <- matrix(c(0, 0, 100, 0, 100, 100, 0, 100, 0, 0),
+                   ncol = 2, byrow = TRUE)
+  poly <- sf::st_polygon(list(coords))
+  if (is.na(crs)) {
+    return(sf::st_sf(id = 1, geometry = sf::st_sfc(poly)))
+  }
+  sf::st_sf(id = 1, geometry = sf::st_sfc(poly, crs = crs))
+}
+
+create_integration_dem <- function(crs = paste0("EPSG:", test_projected_crs)) {
+  dem <- terra::rast(ncol = 10, nrow = 10,
+                     xmin = 0, xmax = 100, ymin = 0, ymax = 100,
+                     crs = crs)
+  terra::values(dem) <- seq(100, 200, length.out = 100)
+  dem
+}
+
+create_integration_rivers <- function(crs = test_projected_crs) {
+  line <- sf::st_linestring(matrix(c(10, 10, 90, 90), ncol = 2, byrow = TRUE))
+  sf::st_sf(id = 1, geometry = sf::st_sfc(line, crs = crs))
+}
+
+expect_no_longlat_warning <- function(expr) {
+  warnings <- character()
+  value <- NULL
+  tryCatch(
+    value <- withCallingHandlers(
+      force(expr),
+      warning = function(w) {
+        warnings <<- c(warnings, conditionMessage(w))
+        invokeRestart("muffleWarning")
+      }
+    ),
+    error = function(e) {
+      # Some integration runs may still fail later because optional model inputs
+      # are intentionally incomplete. Those errors are not part of this check.
+      expect_false(grepl("legacy|Spatial|RasterLayer", e$message))
+    }
+  )
+
+  longlat_warnings <- grep(
+    "longitude/latitude|although coordinates are longitude/latitude|st_buffer|st_simplify",
+    warnings,
+    value = TRUE
+  )
+  expect_length(longlat_warnings, 0)
+  invisible(value)
+}
+
 test_that("auto_build_model rejects legacy raster objects", {
   skip_if_not_installed("raster")
   skip_if_not_installed("terra")
@@ -74,21 +126,9 @@ test_that("auto_build_model accepts terra/sf objects", {
   skip_if_not_installed("terra")
   skip_if_not_installed("sf")
   skip_if_not_installed("RTriangle")
-  skip_if_s2_unavailable()
-  old_s2 <- sf::sf_use_s2()
-  on.exit(sf::sf_use_s2(old_s2))
-  sf::sf_use_s2(FALSE)
-  
-  # Create small test data
-  coords <- matrix(c(0, 0, 100, 0, 100, 100, 0, 100, 0, 0), ncol = 2, byrow = TRUE)
-  poly <- sf::st_polygon(list(coords))
-  domain <- sf::st_sf(id = 1, geometry = sf::st_sfc(poly, crs = 4326))
-  
-  # Create DEM
-  dem <- terra::rast(ncol = 10, nrow = 10, 
-                     xmin = 0, xmax = 100, ymin = 0, ymax = 100,
-                     crs = "EPSG:4326")
-  terra::values(dem) <- seq(100, 200, length.out = 100)
+
+  domain <- create_integration_domain()
+  dem <- create_integration_dem()
   
   # Create temporary output directory
   temp_dir <- tempfile()
@@ -98,7 +138,7 @@ test_that("auto_build_model accepts terra/sf objects", {
   # here we verify it at least accepts sf/terra inputs without
   # type-checking errors (the internal build may fail without
   # complete input data).
-  tryCatch(
+  expect_no_longlat_warning(
     auto_build_model(
       project_name = "test_model",
       domain = domain,
@@ -106,15 +146,145 @@ test_that("auto_build_model accepts terra/sf objects", {
       output_dir = temp_dir,
       years = 2000:2001,
       verbose = FALSE
-    ),
-    error = function(e) {
-      # Accept errors from incomplete inputs, but not from type validation
-      expect_false(grepl("legacy|Spatial|RasterLayer", e$message))
-    }
+    )
   )
   
   # Clean up
   unlink(temp_dir, recursive = TRUE)
+})
+
+test_that("auto_build_model rejects missing CRS on domain", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  domain <- create_integration_domain(crs = NA)
+  dem <- create_integration_dem()
+
+  expect_error(
+    auto_build_model(
+      project_name = "test",
+      domain = domain,
+      dem = dem,
+      verbose = FALSE
+    ),
+    "domain.*projected CRS in metres/meters"
+  )
+})
+
+test_that("auto_build_model rejects longlat CRS on domain", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  domain <- create_integration_domain(crs = 4326)
+  dem <- create_integration_dem()
+
+  expect_error(
+    auto_build_model(
+      project_name = "test",
+      domain = domain,
+      dem = dem,
+      verbose = FALSE
+    ),
+    "domain.*longitude/latitude CRS.*Transform 'domain'"
+  )
+})
+
+test_that("auto_build_model rejects projected feet-unit CRS before spatial operations", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  domain_feet <- create_integration_domain(crs = 2272)
+  dem <- create_integration_dem()
+  expect_error(
+    auto_build_model(
+      project_name = "test",
+      domain = domain_feet,
+      dem = dem,
+      verbose = FALSE
+    ),
+    "domain.*metres/meters.*US survey foot"
+  )
+
+  domain <- create_integration_domain()
+  dem_feet <- create_integration_dem(crs = "EPSG:2272")
+  expect_error(
+    auto_build_model(
+      project_name = "test",
+      domain = domain,
+      dem = dem_feet,
+      verbose = FALSE
+    ),
+    "dem.*metres/meters.*US survey foot"
+  )
+})
+
+test_that("auto_build_model rejects projected feet-unit rivers", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  domain <- create_integration_domain()
+  rivers_feet <- create_integration_rivers(crs = 2272)
+  dem <- create_integration_dem()
+
+  expect_error(
+    auto_build_model(
+      project_name = "test",
+      domain = domain,
+      rivers = rivers_feet,
+      dem = dem,
+      verbose = FALSE
+    ),
+    "rivers.*metres/meters.*US survey foot"
+  )
+})
+
+test_that("auto_build_model rejects longlat rivers with projected domain and DEM", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  domain <- create_integration_domain()
+  rivers <- create_integration_rivers(crs = 4326)
+  dem <- create_integration_dem()
+
+  expect_error(
+    auto_build_model(
+      project_name = "test",
+      domain = domain,
+      rivers = rivers,
+      dem = dem,
+      verbose = FALSE
+    ),
+    "rivers.*longitude/latitude CRS.*Transform 'rivers'"
+  )
+})
+
+test_that("auto_build_model rejects missing or longlat CRS on DEM", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  domain <- create_integration_domain()
+
+  dem_missing_crs <- create_integration_dem(crs = "")
+  expect_error(
+    auto_build_model(
+      project_name = "test",
+      domain = domain,
+      dem = dem_missing_crs,
+      verbose = FALSE
+    ),
+    "dem.*projected CRS in metres/meters"
+  )
+
+  dem_longlat <- create_integration_dem(crs = "EPSG:4326")
+  expect_error(
+    auto_build_model(
+      project_name = "test",
+      domain = domain,
+      dem = dem_longlat,
+      verbose = FALSE
+    ),
+    "dem.*longitude/latitude CRS.*Transform 'dem'"
+  )
 })
 
 test_that("auto_build_model validates required parameters", {
@@ -152,21 +322,9 @@ test_that("quick_model works with minimal inputs", {
   skip_if_not_installed("terra")
   skip_if_not_installed("sf")
   skip_if_not_installed("RTriangle")
-  skip_if_s2_unavailable()
-  old_s2 <- sf::sf_use_s2()
-  on.exit(sf::sf_use_s2(old_s2))
-  sf::sf_use_s2(FALSE)
-  
-  # Create small test data
-  coords <- matrix(c(0, 0, 100, 0, 100, 100, 0, 100, 0, 0), ncol = 2, byrow = TRUE)
-  poly <- sf::st_polygon(list(coords))
-  domain <- sf::st_sf(id = 1, geometry = sf::st_sfc(poly, crs = 4326))
-  
-  # Create DEM
-  dem <- terra::rast(ncol = 10, nrow = 10,
-                     xmin = 0, xmax = 100, ymin = 0, ymax = 100,
-                     crs = "EPSG:4326")
-  terra::values(dem) <- seq(100, 200, length.out = 100)
+
+  domain <- create_integration_domain()
+  dem <- create_integration_dem()
   
   # Create temporary output directory
   temp_dir <- tempfile()
@@ -175,20 +333,15 @@ test_that("quick_model works with minimal inputs", {
   
   # quick_model may fail internally without complete soil/landcover
   # data; verify it at least accepts sf/terra types.
-  tryCatch(
-    {
-      result <- quick_model(
-        project_name = "quick_test",
-        domain = domain,
-        dem = dem,
-        output_dir = temp_dir,
-        years = 2000:2001,
-        verbose = FALSE
-      )
-    },
-    error = function(e) {
-      expect_false(grepl("legacy|Spatial|RasterLayer", e$message))
-    }
+  result <- expect_no_longlat_warning(
+    quick_model(
+      project_name = "quick_test",
+      domain = domain,
+      dem = dem,
+      output_dir = temp_dir,
+      years = 2000:2001,
+      verbose = FALSE
+    )
   )
   if (is.null(result)) {
     return(invisible())
@@ -201,6 +354,24 @@ test_that("quick_model works with minimal inputs", {
   
   # Clean up
   unlink(temp_dir, recursive = TRUE)
+})
+
+test_that("quick_model inherits auto_build_model longlat rejection", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  domain <- create_integration_domain(crs = 4326)
+  dem <- create_integration_dem()
+
+  expect_error(
+    quick_model(
+      project_name = "quick_test",
+      domain = domain,
+      dem = dem,
+      verbose = FALSE
+    ),
+    "domain.*longitude/latitude CRS.*Transform 'domain'"
+  )
 })
 
 test_that("quick_model validates spatial object types", {

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -23,6 +23,9 @@ create_integration_dem <- function(crs = paste0("EPSG:", test_projected_crs)) {
 
 create_integration_rivers <- function(crs = test_projected_crs) {
   line <- sf::st_linestring(matrix(c(10, 10, 90, 90), ncol = 2, byrow = TRUE))
+  if (is.na(crs)) {
+    return(sf::st_sf(id = 1, geometry = sf::st_sfc(line)))
+  }
   sf::st_sf(id = 1, geometry = sf::st_sfc(line, crs = crs))
 }
 
@@ -255,6 +258,64 @@ test_that("auto_build_model rejects longlat rivers with projected domain and DEM
       verbose = FALSE
     ),
     "rivers.*longitude/latitude CRS.*Transform 'rivers'"
+  )
+})
+
+test_that("auto_build_model rejects missing CRS on rivers", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  domain <- create_integration_domain()
+  rivers <- create_integration_rivers(crs = NA)
+  dem <- create_integration_dem()
+
+  expect_error(
+    auto_build_model(
+      project_name = "test",
+      domain = domain,
+      rivers = rivers,
+      dem = dem,
+      verbose = FALSE
+    ),
+    "rivers.*projected CRS in metres/meters"
+  )
+})
+
+test_that("auto_build_model rejects DEM CRS mismatch before spatial operations", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  domain <- create_integration_domain()
+  dem <- create_integration_dem(crs = "EPSG:32618")
+
+  expect_error(
+    auto_build_model(
+      project_name = "test",
+      domain = domain,
+      dem = dem,
+      verbose = FALSE
+    ),
+    "Parameter 'dem' CRS must match 'domain' CRS"
+  )
+})
+
+test_that("auto_build_model rejects river CRS mismatch before spatial operations", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  domain <- create_integration_domain()
+  rivers <- create_integration_rivers(crs = 32618)
+  dem <- create_integration_dem()
+
+  expect_error(
+    auto_build_model(
+      project_name = "test",
+      domain = domain,
+      rivers = rivers,
+      dem = dem,
+      verbose = FALSE
+    ),
+    "Parameter 'rivers' CRS must match 'domain' CRS"
   )
 })
 

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -176,6 +176,26 @@ test_that("projected CRS unit check rejects unknown units", {
                "dem.*CRS units.*could not be determined")
 })
 
+test_that("model builder CRS compatibility normalizes sf and terra CRS", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  coords <- matrix(c(0, 0, 10, 0, 10, 10, 0, 10, 0, 0),
+                   ncol = 2, byrow = TRUE)
+  domain <- sf::st_sf(
+    geometry = sf::st_sfc(sf::st_polygon(list(coords)), crs = 3857)
+  )
+  dem_matching <- terra::rast(ncol = 10, nrow = 10,
+                              xmin = 0, xmax = 10, ymin = 0, ymax = 10,
+                              crs = "EPSG:3857")
+  dem_mismatched <- terra::rast(ncol = 10, nrow = 10,
+                                xmin = 0, xmax = 10, ymin = 0, ymax = 10,
+                                crs = "EPSG:32618")
+
+  expect_true(model_builder_crs_compatible(domain, dem_matching))
+  expect_false(model_builder_crs_compatible(domain, dem_mismatched))
+})
+
 test_that("compatible_crs detects matching CRS", {
   expect_true(compatible_crs("EPSG:4326", "EPSG:4326"))
   expect_true(compatible_crs("+proj=longlat", "+proj=longlat"))

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -95,6 +95,87 @@ test_that("check_spatial_compatible detects non-overlapping extents", {
                "do not overlap")
 })
 
+test_that("projected CRS validators accept projected sf and raster inputs", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  coords <- matrix(c(0, 0, 10, 0, 10, 10, 0, 10, 0, 0),
+                   ncol = 2, byrow = TRUE)
+  domain <- sf::st_sf(
+    geometry = sf::st_sfc(sf::st_polygon(list(coords)), crs = 3857)
+  )
+  dem <- terra::rast(ncol = 10, nrow = 10,
+                     xmin = 0, xmax = 10, ymin = 0, ymax = 10,
+                     crs = "EPSG:3857")
+
+  expect_true(check_sf_projected_crs(domain, "domain"))
+  expect_true(check_raster_projected_crs(dem, "dem"))
+})
+
+test_that("projected CRS validators reject missing CRS", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  coords <- matrix(c(0, 0, 10, 0, 10, 10, 0, 10, 0, 0),
+                   ncol = 2, byrow = TRUE)
+  domain <- sf::st_sf(
+    geometry = sf::st_sfc(sf::st_polygon(list(coords)))
+  )
+  dem <- terra::rast(ncol = 10, nrow = 10,
+                     xmin = 0, xmax = 10, ymin = 0, ymax = 10)
+  terra::crs(dem) <- ""
+
+  expect_error(check_sf_projected_crs(domain, "domain"),
+               "domain.*projected CRS in metres/meters")
+  expect_error(check_raster_projected_crs(dem, "dem"),
+               "dem.*projected CRS in metres/meters")
+})
+
+test_that("projected CRS validators reject longitude latitude CRS", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  coords <- matrix(c(0, 0, 1, 0, 1, 1, 0, 1, 0, 0),
+                   ncol = 2, byrow = TRUE)
+  domain <- sf::st_sf(
+    geometry = sf::st_sfc(sf::st_polygon(list(coords)), crs = 4326)
+  )
+  dem <- terra::rast(ncol = 10, nrow = 10,
+                     xmin = 0, xmax = 1, ymin = 0, ymax = 1,
+                     crs = "EPSG:4326")
+
+  expect_error(check_sf_projected_crs(domain, "domain"),
+               "domain.*longitude/latitude CRS.*Transform 'domain'")
+  expect_error(check_raster_projected_crs(dem, "dem"),
+               "dem.*longitude/latitude CRS.*Transform 'dem'")
+})
+
+test_that("projected CRS validators reject projected feet units", {
+  skip_if_not_installed("terra")
+  skip_if_not_installed("sf")
+
+  coords <- matrix(c(0, 0, 10, 0, 10, 10, 0, 10, 0, 0),
+                   ncol = 2, byrow = TRUE)
+  domain <- sf::st_sf(
+    geometry = sf::st_sfc(sf::st_polygon(list(coords)), crs = 2272)
+  )
+  dem <- terra::rast(ncol = 10, nrow = 10,
+                     xmin = 0, xmax = 10, ymin = 0, ymax = 10,
+                     crs = "EPSG:2272")
+
+  expect_error(check_sf_projected_crs(domain, "domain"),
+               "domain.*metres/meters.*US survey foot")
+  expect_error(check_raster_projected_crs(dem, "dem"),
+               "dem.*metres/meters.*US survey foot")
+})
+
+test_that("projected CRS unit check rejects unknown units", {
+  expect_error(check_crs_units_metres(NA_character_, "domain"),
+               "domain.*CRS units.*could not be determined")
+  expect_error(check_crs_units_metres("", "dem"),
+               "dem.*CRS units.*could not be determined")
+})
+
 test_that("compatible_crs detects matching CRS", {
   expect_true(compatible_crs("EPSG:4326", "EPSG:4326"))
   expect_true(compatible_crs("+proj=longlat", "+proj=longlat"))


### PR DESCRIPTION
## 背景

Fixes #11。

`auto_build_model()` / `quick_model()` 的默认 buffer、simplify、crop、mesh 和属性提取参数是米制空间语义。此前入口只检查 sf/terra 类型，但没有阻止经纬度 CRS、非米制投影 CRS，或多个输入之间 CRS 不一致，可能让空间操作在错误单位或错误坐标系下继续执行，导致 silent wrong output。

## 修复内容

- 在 `auto_build_model()` 入口增加 CRS guard，覆盖 `domain`、`dem`、`rivers`、`forcing_sites`、`soil`、`geology`、`landcover`。
- 新增 projected metre CRS 检查：
  - 缺失 CRS 直接报错。
  - longitude/latitude CRS 直接报错。
  - CRS WKT 必须是 projected CRS（`PROJCRS` / `PROJCS`）。
  - GDAL 单位必须是 `metre` 或 `meter`。
  - EPSG:2272 等 feet-unit projected CRS 会被拒绝，并提示实际单位。
  - 无法解析 WKT 或无法确定单位时不静默通过。
- 新增 model-builder 同 CRS 检查：
  - 所有提供的空间输入必须与 `domain` 使用同一个 CRS。
  - 不做自动重投影，发现不一致直接报错。
  - 避免 `domain=EPSG:3857`、`dem=EPSG:32618` 这类同为米制投影但坐标系不同的 silent wrong output。
- 修正 `tests/testthat/test-integration.R` 中 mock 数据：不再使用 `0..100` 平面坐标却标注 `EPSG:4326`。
- 补充 direct validator 和 top-level `auto_build_model()` / `quick_model()` 测试，覆盖 missing CRS、longlat、feet-unit、mixed CRS 和 `rivers` 缺失 CRS。
- 更新 roxygen / Rd 文档，明确米制投影 CRS 和同 CRS 要求。

## 验证

最终 head: `bf23282b50ac40565bc87de65ef7c77f62e647c8`

- `git diff --check`: PASS
- `Rscript -e 'devtools::test(filter="integration|validation")'`: PASS, `FAIL 0 | WARN 0 | SKIP 0 | PASS 74`
- `Rscript -e 'devtools::test(filter="mesh|plot|gis-core|io|water-balance|integration|validation")'`: PASS, `FAIL 0 | WARN 0 | SKIP 13 | PASS 525`
- `/tmp` 下 `R CMD build --no-build-vignettes /scratch/frd_muziyao/SHUD-System/rSHUD`: PASS
- `/tmp` 下 `R CMD check --no-manual --no-build-vignettes --no-vignettes rSHUD_2.3.0.tar.gz`: `0 ERROR`, `2 WARNING`

## 已知 warning

`R CMD check` 的 2 个 warning 来自禁用 vignette build 时 `vignettes/` 有 Rmd 但没有 `inst/doc` 输出：

- `Files in the 'vignettes' directory but no files in 'inst/doc'`
- `Directory 'inst/doc' does not exist`

这与本 PR 的 CRS guard 修改无关，且与前序本地 check 结果一致。

## Review 结果

- Reviewer agents used: Spec Compliance Reviewer, Correctness Reviewer, Integration Reviewer, Security and Performance Reviewer
- Reviewed head SHA: `bf23282b50ac40565bc87de65ef7c77f62e647c8`
- Review evidence: [Spec](https://github.com/SHUD-System/rSHUD/pull/12#issuecomment-4362351250) | [Correctness](https://github.com/SHUD-System/rSHUD/pull/12#issuecomment-4362353030) | [Integration](https://github.com/SHUD-System/rSHUD/pull/12#issuecomment-4362354515) | [Security/Perf](https://github.com/SHUD-System/rSHUD/pull/12#issuecomment-4362356249)
- Key findings addressed: 补齐 `rivers` 缺失 CRS integration 覆盖；新增跨输入同 CRS guard，拒绝 mixed projected metre CRS。
- Independent final review: PASS，无 blocking issue；残余风险是 CRS equality 故意保守，等价但编码不同的 CRS 可能被拒绝，符合本 issue 的 conservative rejection 策略。

## Artifact 检查

- 仓库内无 `Rplots.pdf`
- 仓库内无 `rSHUD_*.tar.gz`
- 仓库内无 `*.Rcheck`
