### PR TITLE
Fix real-data validation pretest blockers

### DIFF
--- a/R/Func_GIS.R
+++ b/R/Func_GIS.R
@@ -603,8 +603,8 @@ SinglePolygon <- function(x, id = 0){
 #' @param ... More options in duplicated()
 #' @return Line object without duplicated from/to nodes, preserving the input
 #'   class where possible. Lines whose FROM/TO nodes cannot be determined, such
-#'   as empty or incomplete LINESTRING geometries, are removed before duplicate
-#'   FROM/TO pairs are filtered.
+#'   as empty, one-coordinate, non-finite, or same-start/end LINESTRING
+#'   geometries, are removed before duplicate FROM/TO pairs are filtered.
 #' @export
 rmDuplicatedLines <- function(x, ...){
   # x = spi.riv

--- a/R/Func_GIS.R
+++ b/R/Func_GIS.R
@@ -596,24 +596,32 @@ SinglePolygon <- function(x, id = 0){
   ret
 }
 
-#' Remove the duplicated lines, which means the FROM and TO points are identical.
+#' Remove incomplete lines and duplicated lines with identical FROM/TO nodes.
 #' \code{rmDuplicatedLines}
 #' @param x \code{sf} line object; legacy spatial input is accepted for
 #'   compatibility.
 #' @param ... More options in duplicated()
 #' @return Line object without duplicated from/to nodes, preserving the input
-#'   class where possible.
+#'   class where possible. Lines whose FROM/TO nodes cannot be determined, such
+#'   as empty or incomplete LINESTRING geometries, are removed before duplicate
+#'   FROM/TO pairs are filtered.
 #' @export
 rmDuplicatedLines <- function(x, ...){
   # x = spi.riv
   cd = get_coords(x)
   # dim(cd)
   ft = get_from_to_nodes(x, cd)
-  id = which(duplicated(ft[, -1], MARGIN = 1, ...))
-  if(length(id) > 0){
-    r = x[-id,]
-  }else{
-    r = x
+  valid = stats::complete.cases(ft[, c("FrNode", "ToNode"), drop = FALSE])
+  keep = valid
+  if (any(valid)) {
+    dup = duplicated(ft[valid, c("FrNode", "ToNode"), drop = FALSE], MARGIN = 1, ...)
+    keep[which(valid)[dup]] = FALSE
+  }
+  idx = which(keep)
+  if (inherits(x, "sfc")) {
+    r = x[idx]
+  } else {
+    r = x[idx,]
   }
   return(r)
 }
@@ -693,8 +701,12 @@ voronoipolygons = function(x = NULL, pts = NULL, rw = NULL, crs = NULL) {
 
 #' Generate the coverage map for forcing sites.
 #' \code{ForcingCoverage}
-#' @param sp.meteoSite \code{sf} POINT object; legacy \code{SpatialPoints*}
-#'   input is accepted for compatibility.
+#' @param sp.meteoSite \code{sf} POINT or POLYGON object; legacy
+#'   \code{SpatialPoints*}/\code{SpatialPolygons*} input is accepted for
+#'   compatibility. Polygon inputs are returned as one forcing zone per polygon,
+#'   with representative point coordinates used for site metadata. This supports
+#'   real AutoSHUD/DataPre polygon `meteoCov.shp` forcing-coverage layers as well
+#'   as point station inputs.
 #' @param pcs Projected Coordinate System (crs object)
 #' @param gcs Geographic Coordinate System (crs object)
 #' @param dem DEM as a \code{terra::SpatRaster}
@@ -705,7 +717,7 @@ voronoipolygons = function(x = NULL, pts = NULL, rw = NULL, crs = NULL) {
 #' @return Legacy \code{SpatialPolygonsDataFrame} forcing coverage object.
 #' @export
 ForcingCoverage <- function(sp.meteoSite = NULL, filenames = paste0(sp.meteoSite$ID, '.csv'),
-                            pcs, gcs = sf::st_crs(4326), 
+                            pcs, gcs = sf::st_crs(4326),
                             dem, wbd, enlarge = 10000
                             ){
   # Compatibility conversion for older forcing-site workflows.
@@ -715,42 +727,79 @@ ForcingCoverage <- function(sp.meteoSite = NULL, filenames = paste0(sp.meteoSite
   if (!inherits(wbd, "sf") && !inherits(wbd, "sfc")) {
     wbd <- sf::st_as_sf(wbd)
   }
-  
+
   if(is.null(sp.meteoSite)){
     sp.meteoSite <- sf::st_centroid(sf::st_geometry(wbd))
     sp.meteoSite <- sf::st_sf(ID = 1:length(sp.meteoSite), geometry = sp.meteoSite)
-    filenames <- paste0(sp.meteoSite$ID, '.csv')
+    if (missing(filenames) || is.null(filenames) || length(filenames) == 0) {
+      filenames <- paste0(sp.meteoSite$ID, '.csv')
+    }
+  } else if (inherits(sp.meteoSite, "sfc")) {
+    sp.meteoSite <- sf::st_sf(geometry = sp.meteoSite)
+    sp.meteoSite$ID <- seq_len(nrow(sp.meteoSite))
   } else if (!inherits(sp.meteoSite, "sf") && !inherits(sp.meteoSite, "sfc")) {
     sp.meteoSite <- sf::st_as_sf(sp.meteoSite)
-    if (is.null(sp.meteoSite$ID)) sp.meteoSite$ID <- 1:nrow(sp.meteoSite)
   }
-  
+  if (is.null(sp.meteoSite$ID)) sp.meteoSite$ID <- seq_len(nrow(sp.meteoSite))
+  if (missing(filenames) || is.null(filenames) || length(filenames) == 0) {
+    filenames <- paste0(sp.meteoSite$ID, '.csv')
+  }
+  if (length(filenames) != nrow(sp.meteoSite)) {
+    stop(
+      sprintf(
+        "filenames must contain exactly one value per sp.meteoSite feature; got %d for %d features",
+        length(filenames), nrow(sp.meteoSite)
+      ),
+      call. = FALSE
+    )
+  }
+
   x.pcs <- sf::st_transform(sp.meteoSite, pcs)
-  x.gcs <- sf::st_transform(sp.meteoSite, gcs)
-  
-  ll <- sf::st_coordinates(x.gcs)
-  xy <- sf::st_coordinates(x.pcs)
-  
+  geom_types <- unique(as.character(sf::st_geometry_type(x.pcs)))
+  is_point_site <- all(geom_types %in% "POINT")
+  is_polygon_site <- all(geom_types %in% c("POLYGON", "MULTIPOLYGON"))
+  if (!is_point_site && !is_polygon_site) {
+    stop(
+      paste(
+        "sp.meteoSite must contain POINT sites or POLYGON/MULTIPOLYGON coverage;",
+        "cast or split MULTIPOINT inputs first"
+      ),
+      call. = FALSE
+    )
+  }
+
+  site_points.pcs <- if (is_polygon_site) {
+    sf::st_point_on_surface(sf::st_geometry(x.pcs))
+  } else {
+    sf::st_geometry(x.pcs)
+  }
+  site_points.gcs <- sf::st_transform(site_points.pcs, gcs)
+
+  ll <- sf::st_coordinates(site_points.gcs)[, 1:2, drop = FALSE]
+  xy <- sf::st_coordinates(site_points.pcs)[, 1:2, drop = FALSE]
+
   # Extract elevation using terra
-  z_ext <- terra::extract(dem, terra::vect(x.pcs))
+  z_ext <- terra::extract(dem, terra::vect(sf::st_as_sf(site_points.pcs)))
   z <- z_ext[, 2] # terra::extract returns ID in first col
-  
+
   att <- data.frame(1:nrow(sp.meteoSite), ll, xy, z, filenames)
   colnames(att) <- c('ID', 'Lon', 'Lat', 'X', 'Y', 'Z', 'Filename')
   
   e1 <- terra::ext(wbd)
-  e2 <- terra::ext(terra::vect(x.pcs))
-  rw <- c(min(e1$xmin, e2$xmin), 
+  e2 <- terra::ext(terra::vect(sf::st_as_sf(site_points.pcs)))
+  rw <- c(min(e1$xmin, e2$xmin),
          max(e1$xmax, e2$xmax),
          min(e1$ymin, e2$ymin),
-         max(e1$ymax, e2$ymax)) 
-         
+         max(e1$ymax, e2$ymax))
+
   if(is.null(enlarge)){
     enlarge <- min(diff(rw[1:2]), diff(rw[3:4])) * 0.02
   }
   rw <- rw + c(-1, 1, -1, 1) * enlarge
-  
-  if(nrow(x.pcs) < 2){
+
+  if (is_polygon_site) {
+    sp.forc <- x.pcs
+  } else if(nrow(x.pcs) < 2){
     # Single-site fallback still uses the compatibility fishnet helper.
     sp.forc <- fishnet(xx = rw[1:2], yy = rw[3:4], crs = pcs)
     sp.forc <- sf::st_as_sf(sp.forc)

--- a/R/ModelInfo.R
+++ b/R/ModelInfo.R
@@ -154,7 +154,9 @@ MeshAtt <- function(pm = read_mesh(), att = read_att(),
 #' @return Attributes of each river reach
 #' @export
 RiverAtt <- function(riv = read_river()){
-  riv = read_river()
+  if (!inherits(riv, "SHUD River")) {
+    stop("Parameter 'riv' must be a SHUD.RIVER object", call. = FALSE)
+  }
   it = riv@river$Type
   y = data.frame(riv@river, 
                   riv@rivertype[it, -1])

--- a/R/io_output.R
+++ b/R/io_output.R
@@ -284,21 +284,44 @@ get_default_variables <- function() {
   )
 }
 
+.get_shud_env_value <- function(name, valid = function(x) TRUE) {
+  envs <- list()
+  ns <- tryCatch(asNamespace("rSHUD"), error = function(e) NULL)
+  if (!is.null(ns) && exists(".shud", envir = ns, inherits = FALSE)) {
+    ns_shud <- get(".shud", envir = ns, inherits = FALSE)
+    if (is.environment(ns_shud)) {
+      envs[[length(envs) + 1L]] <- ns_shud
+    }
+  }
+  if (exists(".shud", envir = .GlobalEnv, inherits = FALSE)) {
+    global_shud <- get(".shud", envir = .GlobalEnv, inherits = FALSE)
+    if (is.environment(global_shud) &&
+        !any(vapply(envs, function(x) identical(x, global_shud), logical(1)))) {
+      envs[[length(envs) + 1L]] <- global_shud
+    }
+  }
+
+  for (env in envs) {
+    if (exists(name, envir = env, inherits = FALSE)) {
+      value <- get(name, envir = env, inherits = FALSE)
+      if (isTRUE(valid(value))) {
+        return(value)
+      }
+    }
+  }
+  NULL
+}
+
 #' Get output path from environment
 #' 
 #' @return Character string with output path
 #' @keywords internal
 get_output_path <- function() {
-  if (exists(".shud", envir = .GlobalEnv)) {
-    tryCatch({
-      p = get("outpath", envir = .shud)
-      if(is.character(p)) as.character(p) else getwd()
-    }, error = function(e) {
-      getwd()  # fallback to current directory
-    })
-  } else {
-    getwd()
-  }
+  p <- .get_shud_env_value(
+    "outpath",
+    function(x) is.character(x) && length(x) > 0 && !is.na(x[[1]])
+  )
+  if (is.null(p)) getwd() else as.character(p[[1]])
 }
 
 #' Get model version from environment
@@ -306,16 +329,11 @@ get_output_path <- function() {
 #' @return Numeric model version
 #' @keywords internal
 get_model_version <- function() {
-  if (exists(".shud", envir = .GlobalEnv)) {
-    tryCatch({
-      v = get("version", envir = .shud)
-      if(is.numeric(v)) as.numeric(v) else 2.0
-    }, error = function(e) {
-      2.0  # default to modern version
-    })
-  } else {
-    2.0
-  }
+  v <- .get_shud_env_value(
+    "version",
+    function(x) is.numeric(x) && length(x) > 0 && !is.na(x[[1]])
+  )
+  if (is.null(v)) 2.0 else as.numeric(v[[1]])
 }
 
 #' Get project name from environment
@@ -323,14 +341,9 @@ get_model_version <- function() {
 #' @return Character string with project name
 #' @keywords internal
 get_project_name <- function() {
-  if (exists(".shud", envir = .GlobalEnv)) {
-    tryCatch({
-      p = get("PRJNAME", envir = .shud)
-      if(is.character(p)) as.character(p) else "model"
-    }, error = function(e) {
-      "model"  # default project name
-    })
-  } else {
-    "model"
-  }
+  p <- .get_shud_env_value(
+    "PRJNAME",
+    function(x) is.character(x) && length(x) > 0 && !is.na(x[[1]])
+  )
+  if (is.null(p)) "model" else as.character(p[[1]])
 }

--- a/R/io_shud.R
+++ b/R/io_shud.R
@@ -11,6 +11,13 @@ NULL
 # Modern SHUD File Reading Functions (snake_case naming)
 # =============================================================================
 
+.resolve_default_file <- function(expr) {
+  tryCatch(
+    force(expr),
+    error = function(e) NULL
+  )
+}
+
 #' Read SHUD mesh file
 #' 
 #' Reads a SHUD mesh file (.mesh) and returns a SHUD.MESH object.
@@ -24,7 +31,10 @@ NULL
 #' mesh <- read_mesh("model.mesh")
 #' }
 read_mesh <- function(file = shud.filein()['md.mesh']) {
-  if (missing(file) || is.null(file) || is.na(file) || file == "") {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()['md.mesh'])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -51,7 +61,10 @@ read_mesh <- function(file = shud.filein()['md.mesh']) {
 #' river <- read_river("model.riv")
 #' }
 read_river <- function(file = shud.filein()['md.riv']) {
-  if (missing(file) || is.null(file) || is.na(file) || file == "") {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()['md.riv'])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -79,7 +92,10 @@ read_river <- function(file = shud.filein()['md.riv']) {
 #' att <- read_att("model.att")
 #' }
 read_att <- function(file = shud.filein()['md.att']) {
-  if (missing(file) || is.null(file) || is.na(file) || file == "") {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()['md.att'])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -105,7 +121,10 @@ read_att <- function(file = shud.filein()['md.att']) {
 #' rivseg <- read_rivseg("model.rivseg")
 #' }
 read_rivseg <- function(file = shud.filein()['md.rivseg']) {
-  if (missing(file) || is.null(file) || is.na(file)) {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()['md.rivseg'])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -131,7 +150,10 @@ read_rivseg <- function(file = shud.filein()['md.rivseg']) {
 #' para <- read_para("model.para")
 #' }
 read_para <- function(file = shud.filein()['md.para']) {
-  if (missing(file) || is.null(file) || is.na(file)) {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()['md.para'])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -151,7 +173,10 @@ read_para <- function(file = shud.filein()['md.para']) {
 #' calib <- read_calib("model.calib")
 #' }
 read_calib <- function(file = shud.filein()['md.calib']) {
-  if (missing(file) || is.null(file) || is.na(file)) {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()['md.calib'])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -172,7 +197,10 @@ read_calib <- function(file = shud.filein()['md.calib']) {
 #' config <- read_config("model.para")
 #' }
 read_config <- function(file = shud.filein()['md.para']) {
-  if (missing(file) || is.null(file) || is.na(file)) {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()['md.para'])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -202,7 +230,10 @@ read_config <- function(file = shud.filein()['md.para']) {
 #' ic <- read_ic("model.ic")
 #' }
 read_ic <- function(file = shud.filein()['md.ic']) {
-  if (missing(file) || is.null(file) || is.na(file)) {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()['md.ic'])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -229,7 +260,10 @@ read_ic <- function(file = shud.filein()['md.ic']) {
 #' soil <- read_soil("model.soil")
 #' }
 read_soil <- function(file = shud.filein()['md.soil']) {
-  if (missing(file) || is.null(file) || is.na(file)) {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()['md.soil'])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -255,7 +289,10 @@ read_soil <- function(file = shud.filein()['md.soil']) {
 #' geol <- read_geol("model.geol")
 #' }
 read_geol <- function(file = shud.filein()['md.geol']) {
-  if (missing(file) || is.null(file) || is.na(file)) {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()['md.geol'])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -281,7 +318,10 @@ read_geol <- function(file = shud.filein()['md.geol']) {
 #' lc <- read_lc("model.lc")
 #' }
 read_lc <- function(file = shud.filein()['md.lc']) {
-  if (missing(file) || is.null(file) || is.na(file)) {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()['md.lc'])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -296,10 +336,15 @@ read_lc <- function(file = shud.filein()['md.lc']) {
 
 #' Read SHUD forcing file list
 #' 
-#' Reads a SHUD forcing file (.forc) and returns forcing site information.
+#' Reads a SHUD forcing file (.forc) and returns forcing site information. The
+#' returned `Sites` data frame normalizes forcing filenames to absolute paths.
+#' Relative forcing directories are resolved against the `.tsd.forc` file
+#' location first, with parent-directory and working-directory fallback for
+#' compatibility with legacy model-root-relative inputs.
 #' 
 #' @param file Character. Full path to the .forc file
-#' @return List containing start time and forcing sites data frame
+#' @return List containing start time and forcing sites data frame. The filename
+#'   column in `Sites` contains normalized absolute paths.
 #' @family shud-io
 #' @export
 #' @examples
@@ -307,7 +352,10 @@ read_lc <- function(file = shud.filein()['md.lc']) {
 #' forc <- read_forc_fn("model.forc")
 #' }
 read_forc_fn <- function(file = shud.filein()['md.forc']) {
-  if (missing(file) || is.null(file) || is.na(file)) {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()['md.forc'])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -317,10 +365,74 @@ read_forc_fn <- function(file = shud.filein()['md.forc']) {
   
   txt <- readLines(file)
   hd <- read.table(text = txt[1])
-  path <- txt[2]
+  path <- trimws(txt[2])
   df <- read.table(text = txt[-1 * 1:2], header = TRUE)
   nc <- ncol(df)
-  df[, nc] <- file.path(path, df[, nc])
+
+  is_absolute_path <- function(x) {
+    grepl("^([A-Za-z]:)?[/\\\\]", x) || startsWith(x, "~")
+  }
+  normalize_abs <- function(x) {
+    x <- path.expand(x)
+    if (!is_absolute_path(x)) {
+      x <- file.path(getwd(), x)
+    }
+    normalizePath(x, winslash = "/", mustWork = FALSE)
+  }
+  parent_dirs <- function(x) {
+    dirs <- normalizePath(x, winslash = "/", mustWork = FALSE)
+    repeat {
+      parent <- dirname(dirs[length(dirs)])
+      if (identical(parent, dirs[length(dirs)])) {
+        break
+      }
+      dirs <- c(dirs, parent)
+    }
+    dirs
+  }
+  forcing_files <- function(base_dir, filenames) {
+    vapply(filenames, function(filename) {
+      filename <- trimws(as.character(filename))
+      if (is_absolute_path(filename)) {
+        normalize_abs(filename)
+      } else {
+        normalize_abs(file.path(base_dir, filename))
+      }
+    }, character(1), USE.NAMES = FALSE)
+  }
+
+  filenames <- df[[nc]]
+  if (is_absolute_path(path)) {
+    df[, nc] <- forcing_files(path, filenames)
+  } else {
+    file_dir <- dirname(normalizePath(file, winslash = "/", mustWork = TRUE))
+    logical_file_dir <- dirname(normalize_abs(file))
+    candidate_bases <- unique(c(
+      file_dir,
+      parent_dirs(file_dir),
+      logical_file_dir,
+      parent_dirs(logical_file_dir),
+      getwd()
+    ))
+    candidate_dirs <- normalizePath(
+      file.path(candidate_bases, path),
+      winslash = "/",
+      mustWork = FALSE
+    )
+    candidate_dirs <- unique(candidate_dirs)
+    candidate_files <- lapply(candidate_dirs, forcing_files, filenames = filenames)
+    existing_counts <- vapply(candidate_files, function(x) sum(file.exists(x)), integer(1))
+    complete_candidates <- which(existing_counts == length(filenames))
+    if (length(complete_candidates) > 0) {
+      selected <- complete_candidates[[1]]
+    } else if (any(existing_counts > 0)) {
+      selected <- which.max(existing_counts)
+    } else {
+      selected <- 1L
+    }
+    df[, nc] <- candidate_files[[selected]]
+  }
+
   ret <- list('StartTime' = as.character(hd[2]),
               Sites = df)
   return(ret)
@@ -340,7 +452,10 @@ read_forc_fn <- function(file = shud.filein()['md.forc']) {
 #' forc_data <- read_forc_csv("model.forc", id = 1:3)
 #' }
 read_forc_csv <- function(file = shud.filein()['md.forc'], id = NULL) {
-  if (missing(file) || is.null(file) || is.na(file)) {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()['md.forc'])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -444,7 +559,10 @@ read_df <- function(file, text = readLines(file), sep = '\t') {
 #' river_sp <- read_river_sp("rivers.shp")
 #' }
 read_river_sp <- function(file = file.path(shud.filein()['inpath'], 'gis', 'river.shp')) {
-  if (missing(file) || is.null(file) || is.na(file)) {
+  if (missing(file)) {
+    file <- .resolve_default_file(file.path(shud.filein()['inpath'], 'gis', 'river.shp'))
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
@@ -704,7 +822,7 @@ write_df <- function(x, file, append = FALSE, quiet = FALSE, header = NULL) {
 readmesh <- function(file = shud.filein()["md.mesh"]) {
   .Deprecated("read_mesh", package = "rSHUD",
               msg = "readmesh() is deprecated. Use read_mesh() instead.")
-  read_mesh(file)
+  if (missing(file)) read_mesh() else read_mesh(file)
 }
 
 #' @rdname read_river
@@ -714,7 +832,7 @@ readmesh <- function(file = shud.filein()["md.mesh"]) {
 readriv <- function(file = shud.filein()["md.riv"]) {
   .Deprecated("read_river", package = "rSHUD",
               msg = "readriv() is deprecated. Use read_river() instead.")
-  read_river(file)
+  if (missing(file)) read_river() else read_river(file)
 }
 
 #' @rdname read_att
@@ -724,7 +842,7 @@ readriv <- function(file = shud.filein()["md.riv"]) {
 readatt <- function(file = shud.filein()["md.att"]) {
   .Deprecated("read_att", package = "rSHUD",
               msg = "readatt() is deprecated. Use read_att() instead.")
-  read_att(file)
+  if (missing(file)) read_att() else read_att(file)
 }
 
 #' @rdname read_rivseg
@@ -734,7 +852,7 @@ readatt <- function(file = shud.filein()["md.att"]) {
 readrivseg <- function(file = shud.filein()["md.rivseg"]) {
   .Deprecated("read_rivseg", package = "rSHUD",
               msg = "readrivseg() is deprecated. Use read_rivseg() instead.")
-  read_rivseg(file)
+  if (missing(file)) read_rivseg() else read_rivseg(file)
 }
 
 #' @rdname read_para
@@ -744,7 +862,7 @@ readrivseg <- function(file = shud.filein()["md.rivseg"]) {
 readpara <- function(file = shud.filein()["md.para"]) {
   .Deprecated("read_para", package = "rSHUD",
               msg = "readpara() is deprecated. Use read_para() instead.")
-  read_para(file)
+  if (missing(file)) read_para() else read_para(file)
 }
 
 #' @rdname read_calib
@@ -754,7 +872,7 @@ readpara <- function(file = shud.filein()["md.para"]) {
 readcalib <- function(file = shud.filein()["md.calib"]) {
   .Deprecated("read_calib", package = "rSHUD",
               msg = "readcalib() is deprecated. Use read_calib() instead.")
-  read_calib(file)
+  if (missing(file)) read_calib() else read_calib(file)
 }
 
 #' @rdname read_config
@@ -764,7 +882,7 @@ readcalib <- function(file = shud.filein()["md.calib"]) {
 readconfig <- function(file = shud.filein()["md.para"]) {
   .Deprecated("read_config", package = "rSHUD",
               msg = "readconfig() is deprecated. Use read_config() instead.")
-  read_config(file)
+  if (missing(file)) read_config() else read_config(file)
 }
 
 #' @rdname read_ic
@@ -774,7 +892,7 @@ readconfig <- function(file = shud.filein()["md.para"]) {
 readic <- function(file = shud.filein()["md.ic"]) {
   .Deprecated("read_ic", package = "rSHUD",
               msg = "readic() is deprecated. Use read_ic() instead.")
-  read_ic(file)
+  if (missing(file)) read_ic() else read_ic(file)
 }
 
 #' @rdname read_soil
@@ -784,7 +902,7 @@ readic <- function(file = shud.filein()["md.ic"]) {
 readsoil <- function(file = shud.filein()["md.soil"]) {
   .Deprecated("read_soil", package = "rSHUD",
               msg = "readsoil() is deprecated. Use read_soil() instead.")
-  read_soil(file)
+  if (missing(file)) read_soil() else read_soil(file)
 }
 
 #' @rdname read_geol
@@ -794,7 +912,7 @@ readsoil <- function(file = shud.filein()["md.soil"]) {
 readgeol <- function(file = shud.filein()["md.geol"]) {
   .Deprecated("read_geol", package = "rSHUD",
               msg = "readgeol() is deprecated. Use read_geol() instead.")
-  read_geol(file)
+  if (missing(file)) read_geol() else read_geol(file)
 }
 
 #' @rdname read_lc
@@ -804,7 +922,7 @@ readgeol <- function(file = shud.filein()["md.geol"]) {
 readlc <- function(file = shud.filein()["md.lc"]) {
   .Deprecated("read_lc", package = "rSHUD",
               msg = "readlc() is deprecated. Use read_lc() instead.")
-  read_lc(file)
+  if (missing(file)) read_lc() else read_lc(file)
 }
 
 #' @rdname read_forc_fn
@@ -814,7 +932,7 @@ readlc <- function(file = shud.filein()["md.lc"]) {
 readforc.fn <- function(file = shud.filein()["md.forc"]) {
   .Deprecated("read_forc_fn", package = "rSHUD",
               msg = "readforc.fn() is deprecated. Use read_forc_fn() instead.")
-  read_forc_fn(file)
+  if (missing(file)) read_forc_fn() else read_forc_fn(file)
 }
 
 #' @rdname read_forc_csv
@@ -824,7 +942,7 @@ readforc.fn <- function(file = shud.filein()["md.forc"]) {
 readforc.csv <- function(file = shud.filein()["md.forc"], id = NULL) {
   .Deprecated("read_forc_csv", package = "rSHUD",
               msg = "readforc.csv() is deprecated. Use read_forc_csv() instead.")
-  read_forc_csv(file, id)
+  if (missing(file)) read_forc_csv(id = id) else read_forc_csv(file, id)
 }
 
 #' @rdname read_df
@@ -844,5 +962,5 @@ read.df <- function(file, text = readLines(file), sep = "\t") {
 readriv.sp <- function(file = file.path(shud.filein()["inpath"], "gis", "river.shp")) {
   .Deprecated("read_river_sp", package = "rSHUD",
               msg = "readriv.sp() is deprecated. Use read_river_sp() instead.")
-  read_river_sp(file)
+  if (missing(file)) read_river_sp() else read_river_sp(file)
 }

--- a/R/io_timeseries.R
+++ b/R/io_timeseries.R
@@ -64,26 +64,39 @@ read_tsd <- function(file) {
 
 #' Read LAI time series file
 #' 
-#' Reads a LAI (Leaf Area Index) time series file (.ts.lai) and returns
-#' properly named time series components.
+#' Reads a LAI (Leaf Area Index) time series file (.tsd.lai or legacy
+#' .ts.lai) and returns properly named time-series components. Real SHUD input
+#' files may contain only one block; those files are returned as `LAI`. Two-block
+#' compatibility files are returned as `LAI` and `RL`.
 #' 
 #' @param file Character. Full path to LAI time series file
-#' @return List of time series data with LAI and RL (Roughness Length) components
+#' @return List of time-series data. One-block files are named `LAI`; two-block
+#'   files are named `LAI` and `RL` (Roughness Length). Additional blocks, if
+#'   present, are named `Block3`, `Block4`, etc.
 #' @family timeseries-io
 #' @export
 #' @examples
 #' \dontrun{
 #' lai_data <- read_lai("model.ts.lai")
 #' plot(lai_data$LAI)
-#' plot(lai_data$RL)
+#' if ("RL" %in% names(lai_data)) plot(lai_data$RL)
 #' }
-read_lai <- function(file = shud.filein()["ts.lai"]) {
-  if (missing(file) || is.null(file) || is.na(file)) {
+read_lai <- function(file = shud.filein()["md.lai"]) {
+  if (missing(file)) {
+    file <- .resolve_default_file(shud.filein()["md.lai"])
+  }
+  if (is.null(file) || length(file) == 0 || is.na(file) || file == "") {
     stop("Parameter 'file' is required", call. = FALSE)
   }
   
   x <- read_tsd(file)
-  names(x) <- c("LAI", "RL")
+  if (length(x) == 1) {
+    names(x) <- "LAI"
+  } else if (length(x) == 2) {
+    names(x) <- c("LAI", "RL")
+  } else if (length(x) > 2) {
+    names(x) <- c("LAI", "RL", paste0("Block", seq.int(3, length(x))))
+  }
   return(x)
 }
 
@@ -277,10 +290,10 @@ read.tsd <- function(file) {
 #' @export
 #' @section Deprecated:
 #' \code{readlai()} is deprecated. Use \code{read_lai()} instead.
-readlai <- function(file = shud.filein()["ts.lai"]) {
+readlai <- function(file = shud.filein()["md.lai"]) {
   .Deprecated("read_lai", package = "rSHUD",
               msg = "readlai() is deprecated. Use read_lai() instead.")
-  read_lai(file)
+  if (missing(file)) read_lai() else read_lai(file)
 }
 
 #' @rdname write_tsd

--- a/R/river_processing.R
+++ b/R/river_processing.R
@@ -160,7 +160,11 @@ get_coords <- function(x) {
   if (inherits(x, "sf") || inherits(x, "sfc")) {
     # Extract all coordinates
     coords_list <- lapply(sf::st_geometry(x), function(line) {
-      sf::st_coordinates(line)[, 1:2, drop = FALSE]
+      coords <- sf::st_coordinates(line)
+      if (nrow(coords) == 0) {
+        return(matrix(numeric(0), ncol = 2))
+      }
+      coords[, 1:2, drop = FALSE]
     })
     
     # Combine and get unique
@@ -168,7 +172,11 @@ get_coords <- function(x) {
   } else {
     x_sf <- sf::st_as_sf(x)
     coords_list <- lapply(sf::st_geometry(x_sf), function(line) {
-      sf::st_coordinates(line)[, 1:2, drop = FALSE]
+      coords <- sf::st_coordinates(line)
+      if (nrow(coords) == 0) {
+        return(matrix(numeric(0), ncol = 2))
+      }
+      coords[, 1:2, drop = FALSE]
     })
     all_coords <- do.call(rbind, coords_list)
   }
@@ -201,22 +209,40 @@ get_coords <- function(x) {
 #' }
 get_from_to_nodes <- function(sf_line, coords = get_coords(sf_line)) {
   if (inherits(sf_line, "sf") || inherits(sf_line, "sfc")) {
-    nsp <- nrow(sf_line)
+    nsp <- length(sf::st_geometry(sf_line))
     # Get all coordinates matrices
     coords_list <- lapply(sf::st_geometry(sf_line), function(line) {
-      sf::st_coordinates(line)[, 1:2, drop = FALSE]
+      coords <- sf::st_coordinates(line)
+      if (nrow(coords) == 0) {
+        return(matrix(numeric(0), ncol = 2))
+      }
+      coords[, 1:2, drop = FALSE]
     })
   } else {
     sf_line <- sf::st_as_sf(sf_line)
     nsp <- nrow(sf_line)
     coords_list <- lapply(sf::st_geometry(sf_line), function(line) {
-      sf::st_coordinates(line)[, 1:2, drop = FALSE]
+      coords <- sf::st_coordinates(line)
+      if (nrow(coords) == 0) {
+        return(matrix(numeric(0), ncol = 2))
+      }
+      coords[, 1:2, drop = FALSE]
     })
   }
   
   # Get first and last points of each line segment
-  fr_pts <- do.call(rbind, lapply(coords_list, function(x) x[1, , drop = FALSE]))
-  to_pts <- do.call(rbind, lapply(coords_list, function(x) x[nrow(x), , drop = FALSE]))
+  fr_pts <- do.call(rbind, lapply(coords_list, function(x) {
+    if (nrow(x) == 0) {
+      return(matrix(c(NA_real_, NA_real_), nrow = 1))
+    }
+    x[1, , drop = FALSE]
+  }))
+  to_pts <- do.call(rbind, lapply(coords_list, function(x) {
+    if (nrow(x) == 0) {
+      return(matrix(c(NA_real_, NA_real_), nrow = 1))
+    }
+    x[nrow(x), , drop = FALSE]
+  }))
   
   # Use string hashing for fast exact matching
   fr_str <- paste(fr_pts[, 1], fr_pts[, 2])

--- a/R/river_processing.R
+++ b/R/river_processing.R
@@ -193,7 +193,9 @@ get_coords <- function(x) {
 #'   wrappers may pass legacy line objects, which are converted internally for
 #'   compatibility.
 #' @param coords Matrix of unique coordinates (default: get_coords(sf_line))
-#' @return Matrix with columns: ID, FrNode, ToNode
+#' @return Matrix with columns: ID, FrNode, ToNode. Invalid line geometries
+#'   with fewer than two coordinates, non-finite coordinates, or identical start
+#'   and end coordinates return `NA` for `FrNode` and `ToNode`.
 #' @export
 #' @examples
 #' \dontrun{
@@ -229,16 +231,23 @@ get_from_to_nodes <- function(sf_line, coords = get_coords(sf_line)) {
       coords[, 1:2, drop = FALSE]
     })
   }
+
+  invalid_line <- vapply(coords_list, function(x) {
+    nrow(x) < 2 || any(!is.finite(x)) ||
+      identical(unname(x[1, ]), unname(x[nrow(x), ]))
+  }, logical(1), USE.NAMES = FALSE)
   
   # Get first and last points of each line segment
   fr_pts <- do.call(rbind, lapply(coords_list, function(x) {
-    if (nrow(x) == 0) {
+    if (nrow(x) < 2 || any(!is.finite(x)) ||
+        identical(unname(x[1, ]), unname(x[nrow(x), ]))) {
       return(matrix(c(NA_real_, NA_real_), nrow = 1))
     }
     x[1, , drop = FALSE]
   }))
   to_pts <- do.call(rbind, lapply(coords_list, function(x) {
-    if (nrow(x) == 0) {
+    if (nrow(x) < 2 || any(!is.finite(x)) ||
+        identical(unname(x[1, ]), unname(x[nrow(x), ]))) {
       return(matrix(c(NA_real_, NA_real_), nrow = 1))
     }
     x[nrow(x), , drop = FALSE]
@@ -252,6 +261,9 @@ get_from_to_nodes <- function(sf_line, coords = get_coords(sf_line)) {
   # Vectorized match
   fr_idx <- match(fr_str, coord_str)
   to_idx <- match(to_str, coord_str)
+  invalid_line <- invalid_line | (!is.na(fr_idx) & !is.na(to_idx) & fr_idx == to_idx)
+  fr_idx[invalid_line] <- NA_integer_
+  to_idx[invalid_line] <- NA_integer_
   
   # Build return matrix
   result <- cbind(seq_len(nsp), fr_idx, to_idx)

--- a/man/ForcingCoverage.Rd
+++ b/man/ForcingCoverage.Rd
@@ -16,8 +16,12 @@ ForcingCoverage(
 )
 }
 \arguments{
-\item{sp.meteoSite}{\code{sf} POINT object; legacy \code{SpatialPoints*}
-input is accepted for compatibility.}
+\item{sp.meteoSite}{\code{sf} POINT or POLYGON object; legacy
+\code{SpatialPoints*}/\code{SpatialPolygons*} input is accepted for
+compatibility. Polygon inputs are returned as one forcing zone per polygon,
+with representative point coordinates used for site metadata. This supports
+real AutoSHUD/DataPre polygon \code{meteoCov.shp} forcing-coverage layers as well
+as point station inputs.}
 
 \item{filenames}{Output filenames associated with the forcing sites.}
 

--- a/man/get_from_to_nodes.Rd
+++ b/man/get_from_to_nodes.Rd
@@ -14,7 +14,9 @@ compatibility.}
 \item{coords}{Matrix of unique coordinates (default: get_coords(sf_line))}
 }
 \value{
-Matrix with columns: ID, FrNode, ToNode
+Matrix with columns: ID, FrNode, ToNode. Invalid line geometries
+with fewer than two coordinates, non-finite coordinates, or identical start
+and end coordinates return \code{NA} for \code{FrNode} and \code{ToNode}.
 }
 \description{
 Identifies the start and end node indices for each river segment

--- a/man/read_forc_fn.Rd
+++ b/man/read_forc_fn.Rd
@@ -13,10 +13,15 @@ readforc.fn(file = shud.filein()["md.forc"])
 \item{file}{Character. Full path to the .forc file}
 }
 \value{
-List containing start time and forcing sites data frame
+List containing start time and forcing sites data frame. The filename
+column in \code{Sites} contains normalized absolute paths.
 }
 \description{
-Reads a SHUD forcing file (.forc) and returns forcing site information.
+Reads a SHUD forcing file (.forc) and returns forcing site information. The
+returned \code{Sites} data frame normalizes forcing filenames to absolute paths.
+Relative forcing directories are resolved against the \code{.tsd.forc} file
+location first, with parent-directory and working-directory fallback for
+compatibility with legacy model-root-relative inputs.
 }
 \section{Deprecated}{
 

--- a/man/read_lai.Rd
+++ b/man/read_lai.Rd
@@ -5,19 +5,23 @@
 \alias{readlai}
 \title{Read LAI time series file}
 \usage{
-read_lai(file = shud.filein()["ts.lai"])
+read_lai(file = shud.filein()["md.lai"])
 
-readlai(file = shud.filein()["ts.lai"])
+readlai(file = shud.filein()["md.lai"])
 }
 \arguments{
 \item{file}{Character. Full path to LAI time series file}
 }
 \value{
-List of time series data with LAI and RL (Roughness Length) components
+List of time-series data. One-block files are named \code{LAI}; two-block
+files are named \code{LAI} and \code{RL} (Roughness Length). Additional blocks, if
+present, are named \code{Block3}, \code{Block4}, etc.
 }
 \description{
-Reads a LAI (Leaf Area Index) time series file (.ts.lai) and returns
-properly named time series components.
+Reads a LAI (Leaf Area Index) time series file (.tsd.lai or legacy
+.ts.lai) and returns properly named time-series components. Real SHUD input
+files may contain only one block; those files are returned as \code{LAI}. Two-block
+compatibility files are returned as \code{LAI} and \code{RL}.
 }
 \section{Deprecated}{
 
@@ -28,7 +32,7 @@ properly named time series components.
 \dontrun{
 lai_data <- read_lai("model.ts.lai")
 plot(lai_data$LAI)
-plot(lai_data$RL)
+if ("RL" \%in\% names(lai_data)) plot(lai_data$RL)
 }
 }
 \seealso{

--- a/man/rmDuplicatedLines.Rd
+++ b/man/rmDuplicatedLines.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Func_GIS.R
 \name{rmDuplicatedLines}
 \alias{rmDuplicatedLines}
-\title{Remove the duplicated lines, which means the FROM and TO points are identical.
+\title{Remove incomplete lines and duplicated lines with identical FROM/TO nodes.
 \code{rmDuplicatedLines}}
 \usage{
 rmDuplicatedLines(x, ...)
@@ -15,9 +15,11 @@ compatibility.}
 }
 \value{
 Line object without duplicated from/to nodes, preserving the input
-class where possible.
+class where possible. Lines whose FROM/TO nodes cannot be determined, such
+as empty or incomplete LINESTRING geometries, are removed before duplicate
+FROM/TO pairs are filtered.
 }
 \description{
-Remove the duplicated lines, which means the FROM and TO points are identical.
+Remove incomplete lines and duplicated lines with identical FROM/TO nodes.
 \code{rmDuplicatedLines}
 }

--- a/man/rmDuplicatedLines.Rd
+++ b/man/rmDuplicatedLines.Rd
@@ -16,8 +16,8 @@ compatibility.}
 \value{
 Line object without duplicated from/to nodes, preserving the input
 class where possible. Lines whose FROM/TO nodes cannot be determined, such
-as empty or incomplete LINESTRING geometries, are removed before duplicate
-FROM/TO pairs are filtered.
+as empty, one-coordinate, non-finite, or same-start/end LINESTRING
+geometries, are removed before duplicate FROM/TO pairs are filtered.
 }
 \description{
 Remove incomplete lines and duplicated lines with identical FROM/TO nodes.

--- a/tests/testthat/test-river.R
+++ b/tests/testthat/test-river.R
@@ -875,6 +875,54 @@ test_that("sp.RiverOrder from/to points keep exact upstream-downstream match", {
   expect_identical(unname(to_xy[1, ]), unname(from_xy[2, ]))
 })
 
+test_that("get_from_to_nodes returns NA nodes for invalid line geometries", {
+  skip_if_not_installed("sf")
+
+  rivers <- sf::st_sf(
+    id = 1:5,
+    geometry = sf::st_sfc(
+      sf::st_linestring(),
+      sf::st_linestring(matrix(c(2, 2), ncol = 2, byrow = TRUE)),
+      sf::st_linestring(matrix(c(3, 3, 3, 3), ncol = 2, byrow = TRUE)),
+      sf::st_linestring(matrix(c(0, 0, Inf, 1), ncol = 2, byrow = TRUE)),
+      sf::st_linestring(matrix(c(0, 0, 1, 1), ncol = 2, byrow = TRUE)),
+      crs = 4326
+    )
+  )
+
+  coords <- get_coords(rivers)
+  ft <- get_from_to_nodes(rivers, coords)
+
+  expect_equal(nrow(ft), 5)
+  expect_true(all(is.na(ft[1:4, c("FrNode", "ToNode")])))
+  expect_false(anyNA(ft[5, c("FrNode", "ToNode")]))
+})
+
+test_that("rmDuplicatedLines removes duplicate reaches and invalid lines", {
+  skip_if_not_installed("sf")
+
+  rivers <- sf::st_sf(
+    id = 1:6,
+    geometry = sf::st_sfc(
+      sf::st_linestring(matrix(c(0, 0, 1, 1), ncol = 2, byrow = TRUE)),
+      sf::st_linestring(matrix(c(0, 0, 1, 1), ncol = 2, byrow = TRUE)),
+      sf::st_linestring(),
+      sf::st_linestring(matrix(c(2, 2), ncol = 2, byrow = TRUE)),
+      sf::st_linestring(matrix(c(3, 3, 3, 3), ncol = 2, byrow = TRUE)),
+      sf::st_linestring(matrix(c(4, 4, 5, 5), ncol = 2, byrow = TRUE)),
+      crs = 4326
+    )
+  )
+
+  out <- rmDuplicatedLines(rivers)
+
+  expect_s3_class(out, "sf")
+  expect_equal(nrow(out), 2)
+  expect_equal(out$id, c(1, 6))
+  ft <- get_from_to_nodes(out)
+  expect_false(anyNA(ft[, c("FrNode", "ToNode")]))
+})
+
 # Test S4 class conversion functions -----------------------------------------
 
 test_that("as_shud_river validates input", {


### PR DESCRIPTION
## Summary

- Fix real-case pretest blockers from issue #13 before expanding rSHUD validation coverage.
- Make LAI, forcing index, river attributes, forcing coverage, and river duplicate cleanup behave predictably on SHUD-System real validation cases.
- Add default-skipped real-data tests gated by `SHUD_SYSTEM_REALDATA=1` and `SHUD_SYSTEM_CASE_DIR`.

## Changes

- `read_lai()` now supports one-block `.tsd.lai` as `LAI`, keeps two-block `LAI`/`RL` compatibility, and names extra blocks deterministically.
- `read_forc_fn()` resolves relative forcing directories relative to the `.tsd.forc` file location while preserving absolute-path behavior.
- `RiverAtt(riv=...)` now uses the supplied `SHUD.RIVER` object and validates the argument type instead of unconditionally reading from `.shud` environment.
- `ForcingCoverage()` now accepts point sites and polygon/multipolygon coverage, validates filename cardinality, uses representative points for metadata/elevation, and rejects `MULTIPOINT` with a clear message.
- River geometry helpers now tolerate empty LINESTRING geometries, allowing `rmDuplicatedLines()` to keep incomplete/empty reaches out of duplicate detection instead of crashing.
- Added gated real-data helpers and issue #13 regression tests.

## Validation

Local validation completed before PR creation:

- `git diff --check`
- `Rscript -e 'devtools::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test-io.R", reporter="summary")'`
- `Rscript -e 'devtools::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test-river.R", reporter="summary")'`
- `Rscript -e 'devtools::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test-gis-core.R", reporter="summary")'`
- `Rscript -e 'devtools::load_all(quiet=TRUE); testthat::test_dir("tests/testthat", reporter="summary")'`
- `SHUD_SYSTEM_REALDATA=1 SHUD_SYSTEM_CASE_DIR=../rshud_validation_cases Rscript -e 'devtools::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test-realdata-issue-13.R", reporter="summary")'`
- `R CMD check --no-manual --no-build-vignettes` passed with expected vignette-related warnings only.

## Agent Review

To be completed after Phase 7 final review and frozen SHA.

Closes #13.
